### PR TITLE
Projects env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To use `contented`:
 - put your analysis deliverables in a directory on the webserver;
 - follow the provisioning notes in `./deploy_tools/provisioning_notes.md` (eg,
   install python / nginx etc on the webserver)
-- run the fabric script in `./deploy_tools` - this will clone the contented
+- run the fabric script in `./deploy_tools` - this will clone the `contented`
   repository onto the webserver, install the python env / update the database
   etc
 - then add the filepath for your analysis deliverables to the `PROJECTS_DIR`
@@ -54,7 +54,7 @@ Use Django test client to check that which templates are used in response to a
 http request, eg, `self.client.get("/")`
 
 Note you can use `@override_settings` decorator, if you want to change the
-project data that is presented by contented during tests (plan is to use env
+project data that is presented by `contented` during tests (plan is to use env
 variable to define the location of the data that is presented; this env var
 will be parsed by settings.py)
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,18 @@ This is a django project for delivery of data-analysis results (notebooks,
 tables etc) in a user-authorised way: Only those users with access to a given
 project should be able to view it's deliverables.
 
-To use `contented`: fork the repository, add your analysis deliverables to the
-`projects` subdirectory and then pull the modified repository onto a web-server
-(details follow).
+To use `contented`:
+
+- obtain a webserver, register a website domain and point the website URL to
+  the webserver;
+- put your analysis deliverables in a directory on the webserver;
+- follow the provisioning notes in `./deploy_tools/provisioning_notes.md` (eg,
+  install python / nginx etc on the webserver)
+- run the fabric script in `./deploy_tools` - this will clone the contented
+  repository onto the webserver, install the python env / update the database
+  etc
+- then add the filepath for your analysis deliverables to the `PROJECTS_DIR`
+  environment variable defined in `./.env`
 
 ## ENV
 
@@ -21,11 +30,12 @@ Environment is managed by `pipenv`
 
 ## CONFIG
 
-A directory is specified by the user (in `config/settings.py`) that contains
-all projects that should be made visible: `PROJECTS_DIR`. The default value of
-`PROJECTS_DIR` points to a set of projects that are used during testing.
+A directory is specified by the superuser (as the `PROJECTS_DIR` environment
+var on the webserver; to do this modify the value in `.env`) that contains all
+projects that should be made visible: `PROJECTS_DIR`.
 
-PLAN: make `PROJECTS_DIR` configurable using environment variables
+The default value of `PROJECTS_DIR` points to a set of projects that are used
+during testing.
 
 ## Tests
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -128,7 +128,9 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static")
 # The set of projects, for which results should be released, are assumed to be
 # present in this directory
 
-PROJECTS_DIR = Path("dummy_projects")
+PROJECTS_DIR = Path(
+    os.getenv("PROJECTS_DIR", "dummy_projects")
+)
 
 # The set of projects that are restricted are defined here:
 

--- a/deploy_tools/template.env
+++ b/deploy_tools/template.env
@@ -1,3 +1,4 @@
 DJANGO_DEBUG_FALSE=y
 SITENAME=my-sitename.co.uk
 DJANGO_SECRET_KEY=some-random-key
+# PROJECTS_DIR=../../project_data


### PR DESCRIPTION
closes #11

Use `PROJECTS_DIR` env var to define which directory should be presented to the public.