### PR TITLE
Restricted env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ To use `contented`:
 - run the fabric script in `./deploy_tools` - this will clone the `contented`
   repository onto the webserver, install the python env / update the database
   etc
-- then add the filepath for your analysis deliverables to the `PROJECTS_DIR`
-  environment variable defined in `./.env`
+- then configure the files that users can see by modifying the `./.env` file,
+  as described in the 'CONFIG' section below
 
 ## ENV
 
@@ -30,12 +30,24 @@ Environment is managed by `pipenv`
 
 ## CONFIG
 
-A directory is specified by the superuser (as the `PROJECTS_DIR` environment
-var on the webserver; to do this modify the value in `.env`) that contains all
-projects that should be made visible: `PROJECTS_DIR`.
+The file `./.env` is used to configure each deployment of `contented`.
 
-The default value of `PROJECTS_DIR` points to a set of projects that are used
-during testing.
+Each line of this file defines an environment variable used while `contented`
+runs.
+
+A template .env file can be found in `./deploy_tools/template.env`
+
+The config variables are:
+
+- `PROJECTS_DIR`: A directory that contains all projects that should be made
+  visible on the website. The default value points to a set of projects that
+  are used during testing.
+
+- `RESTRICTED_PROJECTS`: Access to a subset of the projects in `PROJECTS_DIR`
+  may be restricted (users must be logged in to view them) by adding their
+  names to this comma-separated string. The default is for all projects to be
+  publicly accessible (this occurs when `RESTRICTED_PROJECTS` is missing or the
+  empty string).
 
 ## Tests
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -128,13 +128,14 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static")
 # The set of projects, for which results should be released, are assumed to be
 # present in this directory
 
-PROJECTS_DIR = Path(
-    os.getenv("PROJECTS_DIR", "dummy_projects")
-)
+PROJECTS_DIR = Path(os.getenv("PROJECTS_DIR", "dummy_projects"))
 
-# The set of projects that are restricted are defined here:
+# The set of projects that are access-restricted
+# - are defined by the comma-separated env variable "RESTRICTED_PROJECTS";
+# - if that var is missing or an empty string, all projects are
+# assumed to be publicly accessible:
 
-RESTRICTED_PROJECTS = []
+RESTRICTED_PROJECTS = [x for x in os.getenv("RESTRICTED_PROJECTS", "").split(",") if x]
 
 # Move the user to the homepage on login/logout
 

--- a/deploy_tools/template.env
+++ b/deploy_tools/template.env
@@ -2,3 +2,4 @@ DJANGO_DEBUG_FALSE=y
 SITENAME=my-sitename.co.uk
 DJANGO_SECRET_KEY=some-random-key
 # PROJECTS_DIR=../../project_data
+# RESTRICTED_PROJECTS=hidden-project1,some-other-project


### PR DESCRIPTION
closes #12

Access-restricted projects can be configured by setting the env-variable `RESTRICTED_PROJECTS` (a comma-separated string) in the `.env` file.